### PR TITLE
Update: import os in configuration/__init__.py file

### DIFF
--- a/configuration/__init__.py
+++ b/configuration/__init__.py
@@ -1,5 +1,6 @@
 from app import app
 import urllib
+import os
 
 # secret key for user session
 app.secret_key = "ITSASECRET"


### PR DESCRIPTION
The `import os` was not added in file and `os.environ['DB_PASSWORD']` was used in file. So, imported the `os`